### PR TITLE
fix: update Gitleaks repository URL in README and utils.bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-gitleaks [![Build](https://github.com/jmcvetta/asdf-gitleaks/actions/workflows/build.yml/badge.svg)](https://github.com/jmcvetta/asdf-gitleaks/actions/workflows/build.yml) [![Lint](https://github.com/jmcvetta/asdf-gitleaks/actions/workflows/lint.yml/badge.svg)](https://github.com/jmcvetta/asdf-gitleaks/actions/workflows/lint.yml)
 
 
-[Gitleaks](https://github.com/zricethezav/gitleaks) plugin for the [asdf version manager](https://asdf-vm.com).
+[Gitleaks](https://github.com/gitleaks/gitleaks) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/zricethezav/gitleaks"
+GH_REPO="https://github.com/gitleaks/gitleaks"
 TOOL_NAME="gitleaks"
 TOOL_TEST="gitleaks --help"
 
@@ -63,7 +63,7 @@ download_release() {
     ;;
   esac
 
-  # https://github.com/zricethezav/gitleaks/releases/download/v8.13.0/gitleaks_8.13.0_linux_x64.tar.gz
+  # https://github.com/gitleaks/gitleaks/releases/download/v8.13.0/gitleaks_8.13.0_linux_x64.tar.gz
   url="$GH_REPO/releases/download/v${version}/gitleaks_${version}_${os}_${arch}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."


### PR DESCRIPTION
Updated the repository based on the links on https://gitleaks.io/